### PR TITLE
__all__ attribute should contain strings, not types

### DIFF
--- a/sortedcontainers/__init__.py
+++ b/sortedcontainers/__init__.py
@@ -52,4 +52,4 @@ from .sortedset import SortedSet
 from .sorteddict import SortedDict
 from .sortedlistwithkey import SortedListWithKey
 
-__all__ = [SortedList, SortedSet, SortedDict, SortedListWithKey]
+__all__ = ['SortedList', 'SortedSet', 'SortedDict', 'SortedListWithKey']


### PR DESCRIPTION
This commit just changes the `__all__` attribute in `sorted_containers/__init__.py` to contain the names of the types rather than the types themselves so that  `from sortedcontainers import *` will work as intended. 

From https://docs.python.org/2/reference/simple_stmts.html#import

> The public names defined by a module are determined by checking the module’s namespace for a variable named `__all__`; if defined, it must be a sequence of strings which are names defined or imported by that module. The names given in `__all__` are all considered public and are required to exist. If `__all__` is not defined, the set of public names includes all names found in the module’s namespace which do not begin with an underscore character (`'_'`). `__all__` should contain the entire public API. It is intended to avoid accidentally exporting items that are not part of the API (such as library modules which were imported and used within the module).
