### PR TITLE
Changes for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
     - python: pypy
       env: TOXENV=pypy
     - python: pypy3
       env: TOXENV=pypy3
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,12 @@ matrix:
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7
+      dist: xenial
       env: TOXENV=py37
     - python: pypy
       env: TOXENV=pypy
     - python: pypy3
       env: TOXENV=pypy3
     - python: 3.7
+      dist: xenial
       env: TOXENV=lint

--- a/README.rst
+++ b/README.rst
@@ -111,8 +111,8 @@ Features
 - Compatible API (nearly identical to older blist and bintrees modules)
 - Feature-rich (e.g. get the five largest keys in a sorted dict: d.keys()[-5:])
 - Pragmatic design (e.g. SortedSet is a Python set with a SortedList index)
-- Developed on Python 3.6
-- Tested on CPython 2.7, 3.2, 3.3, 3.4, 3.5, 3.6 and PyPy, PyPy3
+- Developed on Python 3.7
+- Tested on CPython 2.7, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7 and PyPy, PyPy3
 
 .. image:: https://api.travis-ci.org/grantjenks/python-sortedcontainers.svg?branch=master
    :target: http://www.grantjenks.com/docs/sortedcontainers/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,12 @@ environment:
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
 
 install:
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -220,6 +220,7 @@ of Python:
 * CPython 3.4
 * CPython 3.5
 * CPython 3.6
+* CPython 3.7
 * PyPy
 * PyPy3
 

--- a/docs/performance-load.rst
+++ b/docs/performance-load.rst
@@ -17,7 +17,7 @@ in-depth analysis of the load factor read :doc:`Performance at
 Scale<performance-scale>`.
 
 Performance of competing implementations are benchmarked against the CPython
-3.6 runtime. An :doc:`implementation performance comparison<performance>` is
+3.7 runtime. An :doc:`implementation performance comparison<performance>` is
 also included with data from popular sorted collections packages.
 
 Because :doc:`Sorted Containers<index>` is pure-Python, its performance also

--- a/docs/performance-runtime.rst
+++ b/docs/performance-runtime.rst
@@ -4,17 +4,17 @@ Runtime Performance Comparison
 Because :doc:`Sorted Containers<index>` is implemented in pure-Python, its
 performance depends directly on the Python runtime. :doc:`Sorted
 Containers<index>` is primarily developed, tested and benchmarked on CPython
-3.6.
+3.7.
 
 Not all runtimes are created equal. The graphs below compare :doc:`Sorted
-Containers<index>` running on the CPython 3.6, CPython 2.7, and PyPy
-runtimes. As of Python 3.6 the CPython 3.6 runtime is now faster than the
+Containers<index>` running on the CPython 3.7, CPython 2.7, and PyPy
+runtimes. As of Python 3.7 the CPython 3.7 runtime is now faster than the
 CPython 2.7 runtime. The PyPy runtime displays much more variability due to its
 JIT-ed nature. Once the just-in-time compiler optimizes the code, performance
 is often two to ten times faster.
 
 Performance of competing implementations are benchmarked against the CPython
-3.6 runtime. An :doc:`implementation performance comparison<performance>` is
+3.7 runtime. An :doc:`implementation performance comparison<performance>` is
 also included with data from popular sorted container packages.
 
 :doc:`Sorted Containers<index>` uses a segmented-list data structure similar to

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ),

--- a/tests/benchmark.sh
+++ b/tests/benchmark.sh
@@ -4,31 +4,31 @@ set -x
 
 # Compare Implementations
 
-echo ". env36/bin/activate && python -m tests.benchmark_sortedlist --bare > tests/results_sortedlist.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sortedlist --bare > tests/results_sortedlist.txt" | bash
 python -m tests.benchmark_plot tests/results_sortedlist.txt SortedList --save
 
-echo ". env36/bin/activate && python -m tests.benchmark_sorteddict --bare > tests/results_sorteddict.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sorteddict --bare > tests/results_sorteddict.txt" | bash
 python -m tests.benchmark_plot tests/results_sorteddict.txt SortedDict --save
 
-echo ". env36/bin/activate && python -m tests.benchmark_sortedset --bare > tests/results_sortedset.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sortedset --bare > tests/results_sortedset.txt" | bash
 python -m tests.benchmark_plot tests/results_sortedset.txt SortedSet --save
 
 # Compare Python Versions
 
 rm tests/results_runtime_sortedlist.txt
-echo ". env36/bin/activate && python -m tests.benchmark_sortedlist --bare --kind SortedList --suffix _Py36 >> tests/results_runtime_sortedlist.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sortedlist --bare --kind SortedList --suffix _Py37 >> tests/results_runtime_sortedlist.txt" | bash
 echo ". env27/bin/activate && python -m tests.benchmark_sortedlist --bare --kind SortedList --suffix _Py27 >> tests/results_runtime_sortedlist.txt" | bash
 echo ". env27/bin/activate && pypy -m tests.benchmark_sortedlist --bare --kind SortedList --suffix _PyPy >> tests/results_runtime_sortedlist.txt" | bash
 python -m tests.benchmark_plot tests/results_runtime_sortedlist.txt SortedList --suffix _runtime --save
 
 rm tests/results_runtime_sorteddict.txt
-echo ". env36/bin/activate && python -m tests.benchmark_sorteddict --bare --kind SortedDict --suffix _Py36 >> tests/results_runtime_sorteddict.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sorteddict --bare --kind SortedDict --suffix _Py37 >> tests/results_runtime_sorteddict.txt" | bash
 echo ". env27/bin/activate && python -m tests.benchmark_sorteddict --bare --kind SortedDict --suffix _Py27 >> tests/results_runtime_sorteddict.txt" | bash
 echo ". env27/bin/activate && pypy -m tests.benchmark_sorteddict --bare --kind SortedDict --suffix _PyPy >> tests/results_runtime_sorteddict.txt" | bash
 python -m tests.benchmark_plot tests/results_runtime_sorteddict.txt SortedDict --suffix _runtime --save
 
 rm tests/results_runtime_sortedset.txt
-echo ". env36/bin/activate && python -m tests.benchmark_sortedset --bare --kind SortedSet --suffix _Py36 >> tests/results_runtime_sortedset.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sortedset --bare --kind SortedSet --suffix _Py37 >> tests/results_runtime_sortedset.txt" | bash
 echo ". env27/bin/activate && python -m tests.benchmark_sortedset --bare --kind SortedSet --suffix _Py27 >> tests/results_runtime_sortedset.txt" | bash
 echo ". env27/bin/activate && pypy -m tests.benchmark_sortedset --bare --kind SortedSet --suffix _PyPy >> tests/results_runtime_sortedset.txt" | bash
 python -m tests.benchmark_plot tests/results_runtime_sortedset.txt SortedSet --suffix _runtime --save
@@ -36,19 +36,19 @@ python -m tests.benchmark_plot tests/results_runtime_sortedset.txt SortedSet --s
 # Compare Loads
 
 rm tests/results_load_sortedlist.txt
-echo ". env36/bin/activate && python -m tests.benchmark_sortedlist --bare --kind SortedList --suffix _100 --load 100 --no-limit >> tests/results_load_sortedlist.txt" | bash
-echo ". env36/bin/activate && python -m tests.benchmark_sortedlist --bare --kind SortedList --suffix _1000 --load 1000 --no-limit >> tests/results_load_sortedlist.txt" | bash
-echo ". env36/bin/activate && python -m tests.benchmark_sortedlist --bare --kind SortedList --suffix _10000 --load 10000 --no-limit >> tests/results_load_sortedlist.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sortedlist --bare --kind SortedList --suffix _100 --load 100 --no-limit >> tests/results_load_sortedlist.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sortedlist --bare --kind SortedList --suffix _1000 --load 1000 --no-limit >> tests/results_load_sortedlist.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sortedlist --bare --kind SortedList --suffix _10000 --load 10000 --no-limit >> tests/results_load_sortedlist.txt" | bash
 python -m tests.benchmark_plot tests/results_load_sortedlist.txt SortedList --suffix _load --save
 
 rm tests/results_load_sorteddict.txt
-echo ". env36/bin/activate && python -m tests.benchmark_sorteddict --bare --kind SortedDict --suffix _100 --load 100 --no-limit >> tests/results_load_sorteddict.txt" | bash
-echo ". env36/bin/activate && python -m tests.benchmark_sorteddict --bare --kind SortedDict --suffix _1000 --load 1000 --no-limit >> tests/results_load_sorteddict.txt" | bash
-echo ". env36/bin/activate && python -m tests.benchmark_sorteddict --bare --kind SortedDict --suffix _10000 --load 10000 --no-limit >> tests/results_load_sorteddict.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sorteddict --bare --kind SortedDict --suffix _100 --load 100 --no-limit >> tests/results_load_sorteddict.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sorteddict --bare --kind SortedDict --suffix _1000 --load 1000 --no-limit >> tests/results_load_sorteddict.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sorteddict --bare --kind SortedDict --suffix _10000 --load 10000 --no-limit >> tests/results_load_sorteddict.txt" | bash
 python -m tests.benchmark_plot tests/results_load_sorteddict.txt SortedDict --suffix _load --save
 
 rm tests/results_load_sortedset.txt
-echo ". env36/bin/activate && python -m tests.benchmark_sortedset --bare --kind SortedSet --suffix _100 --load 100 --no-limit >> tests/results_load_sortedset.txt" | bash
-echo ". env36/bin/activate && python -m tests.benchmark_sortedset --bare --kind SortedSet --suffix _1000 --load 1000 --no-limit >> tests/results_load_sortedset.txt" | bash
-echo ". env36/bin/activate && python -m tests.benchmark_sortedset --bare --kind SortedSet --suffix _10000 --load 10000 --no-limit >> tests/results_load_sortedset.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sortedset --bare --kind SortedSet --suffix _100 --load 100 --no-limit >> tests/results_load_sortedset.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sortedset --bare --kind SortedSet --suffix _1000 --load 1000 --no-limit >> tests/results_load_sortedset.txt" | bash
+echo ". env37/bin/activate && python -m tests.benchmark_sortedset --bare --kind SortedSet --suffix _10000 --load 10000 --no-limit >> tests/results_load_sortedset.txt" | bash
 python -m tests.benchmark_plot tests/results_load_sortedset.txt SortedSet --suffix _load --save

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,pypy,pypy3,lint
+envlist=py27,py34,py35,py36,py37,pypy,pypy3,lint
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
Reference: #100 and #99 

Note that sortedcontainers works fine on Python 3.7 this just updates the docs and benchmarks.