### PR TITLE
Restore support for iter/view keys/values/items on Python 2.

### DIFF
--- a/sortedcontainers/sorteddict.py
+++ b/sortedcontainers/sorteddict.py
@@ -29,7 +29,7 @@ from .sortedset import SortedSet
 try:
     from collections.abc import ItemsView, KeysView, ValuesView, Sequence
 except ImportError:
-    from collections import ItemsView, KeysView, ValuesView, Sequence
+    from collections import ItemsView, KeysView, ValuesView, Sequence, Mapping
 
 ###############################################################################
 # END Python 2/3 Shims
@@ -371,25 +371,13 @@ class SortedDict(dict):
 
 
     if sys.hexversion < 0x03000000:
-        def __make_raise_attributeerror(original, alternate):
-            # pylint: disable=no-self-argument
-            message = (
-                'SortedDict.{original}() is not implemented.'
-                ' Use SortedDict.{alternate}() instead.'
-            ).format(original=original, alternate=alternate)
-            def method(self):
-                # pylint: disable=missing-docstring,unused-argument
-                raise AttributeError(message)
-            method.__name__ = original
-            method.__doc__ = message
-            return property(method)
-
-        iteritems = __make_raise_attributeerror('iteritems', 'items')
-        iterkeys = __make_raise_attributeerror('iterkeys', 'keys')
-        itervalues = __make_raise_attributeerror('itervalues', 'values')
-        viewitems = __make_raise_attributeerror('viewitems', 'items')
-        viewkeys = __make_raise_attributeerror('viewkeys', 'keys')
-        viewvalues = __make_raise_attributeerror('viewvalues', 'values')
+        # pylint: disable=E1101,W0108
+        iteritems = Mapping.iteritems
+        iterkeys = Mapping.iterkeys
+        itervalues = Mapping.itervalues
+        viewitems = lambda self: SortedItemsView(self)
+        viewkeys = lambda self: SortedKeysView(self)
+        viewvalues = lambda self: SortedValuesView(self)
 
 
     class _NotGiven(object):

--- a/tests/test_coverage_sorteddict.py
+++ b/tests/test_coverage_sorteddict.py
@@ -215,11 +215,6 @@ def test_values():
     temp = SortedDict(mapping)
     assert list(temp.values()) == [pos for key, pos in mapping]
 
-def test_iterkeys():
-    temp = SortedDict()
-    with pytest.raises(AttributeError):
-        temp.iterkeys
-
 def test_notgiven():
     assert repr(SortedDict._SortedDict__not_given) == '<not-given>'
 


### PR DESCRIPTION
Hi @grantjenks,

I just noticed the changes in 3367ea5 and I'm trying to understand the rationale. The new lack of an `iteritems()` method actually broke some of my code, and I wouldn't be surprised if it broke others' too.

Since `SortedDict` implements the `collections.Mapping` interface, why not let it use the generic implementations of these methods defined in _abcoll.py, rather than raising `AttributeError`? e.g. https://github.com/python/cpython/blob/2.7/Lib/_abcoll.py#L403 defines the following `iteritems()` implementation:

```python
class Mapping(Sized, Iterable, Container):
    ...
    def iteritems(self):
        'D.iteritems() -> an iterator over the (key, value) items of D'
        for key in self:
            yield (key, self[key])
```

Doesn't using this with SortedDict work fine, and improve interoperability with other code?

I expect this change broke interoperability with other libraries as well. It's common to define a Python 2/3-compatible `iteritems` implementation, that assumes it can safely call `.iteritems()` on a `Mapping` when on Python 2. Here are a few examples:

- https://github.com/pallets/werkzeug/blob/26bcfe6/werkzeug/_compat.py#L28
- https://github.com/pandas-dev/pandas/blob/d78bd7/pandas/compat/__init__.py#L208
- https://github.com/jab/bidict/blob/2044860/bidict/compat.py#L75

Thanks and look forward to hearing what you think.