### PR TITLE
Fix a warning under Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     tests_require=['tox'],
     cmdclass={'test': Tox},
     install_requires=[],
-    classifiers=(
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
@@ -48,5 +48,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
-    ),
+    ],
 )


### PR DESCRIPTION
`Warning: 'classifiers' should be a list, got type 'tuple'`

Related issue: https://bugs.python.org/issue19610