### PR TITLE
improve SortedList.__getitem__() performance for small slices

### DIFF
--- a/sortedcontainers/sortedlist.py
+++ b/sortedcontainers/sortedlist.py
@@ -842,14 +842,15 @@ class SortedList(MutableSequence):
 
                 start_pos, start_idx = self._pos(start)
 
+                slice_len = stop - start
+                if len(_lists[start_pos]) >= start_idx + slice_len:
+                    return _lists[start_pos][start_idx:start_idx+slice_len]
+
                 if stop == self._len:
                     stop_pos = len(_lists) - 1
                     stop_idx = len(_lists[stop_pos])
                 else:
                     stop_pos, stop_idx = self._pos(stop)
-
-                if start_pos == stop_pos:
-                    return _lists[start_pos][start_idx:stop_idx]
 
                 prefix = _lists[start_pos][start_idx:]
                 middle = _lists[(start_pos + 1):stop_pos]


### PR DESCRIPTION
Fixes #117.

before:
```
$ python -m timeit -s 'from sortedcontainers import SortedList; l = SortedList(range(100_0000))' 'l[50_000:50_003]'
50000 loops, best of 5: 5.84 usec per loop
```

after:
```
$ python -m timeit -s 'from sortedcontainers import SortedList; l = SortedList(range(100_0000))' 'l[50_000:50_003]'
100000 loops, best of 5: 3.57 usec per loop
```

non-slice baseline:
```
$ python -m timeit -s 'from sortedcontainers import SortedList; l = SortedList(range(100_0000))' 'l[50_000]'
100000 loops, best of 5: 3.34 usec per loop
```