### PR TITLE
Include regression tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst LICENSE
+recursive-include tests/ *


### PR DESCRIPTION
Include regression tests in PyPI tarball for easy regression testing by distributors.

In OpenBSD we use regression tests to make sure nothing has been broken by changes in the main OS or updates of other ports. Having to pull tests from github rather than PyPI makes it harder to do those tests.