### PR TITLE
Use sys.version_info instead of sys.hexversion

### DIFF
--- a/sortedcontainers/sorteddict.py
+++ b/sortedcontainers/sorteddict.py
@@ -370,7 +370,7 @@ class SortedDict(dict):
         return SortedValuesView(self)
 
 
-    if sys.hexversion < 0x03000000:
+    if sys.version_info < (3,):
         def __make_raise_attributeerror(original, alternate):
             # pylint: disable=no-self-argument
             message = (

--- a/sortedcontainers/sortedlist.py
+++ b/sortedcontainers/sortedlist.py
@@ -32,9 +32,9 @@ except ImportError:
     from collections import Sequence, MutableSequence
 
 from functools import wraps
-from sys import hexversion
+from sys import version_info
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     from itertools import imap as map  # pylint: disable=redefined-builtin
     from itertools import izip as zip  # pylint: disable=redefined-builtin
     try:

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from sys import hexversion
+from sys import version_info
 import logging
 
 import time, random, argparse
@@ -9,7 +9,7 @@ try:
 except:
     from ordereddict import OrderedDict
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     range = xrange
     name_attr = 'func_name'
 else:

--- a/tests/benchmark_sortedset.py
+++ b/tests/benchmark_sortedset.py
@@ -3,11 +3,11 @@ Benchmark Sorted Set Datatypes
 """
 
 import warnings
-from sys import hexversion
+from sys import version_info
 
 from .benchmark import *
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     range = xrange
 
 # Tests.

--- a/tests/test_coverage_sorteddict.py
+++ b/tests/test_coverage_sorteddict.py
@@ -4,9 +4,9 @@ import random, string
 from .context import sortedcontainers
 from sortedcontainers import SortedDict
 import pytest
-from sys import hexversion
+from sys import version_info
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     range = xrange
 
 def negate(value):
@@ -16,13 +16,13 @@ def modulo(value):
     return value % 10
 
 def get_keysview(dic):
-    if hexversion < 0x03000000:
+    if version_info < (3,):
         return dic.viewkeys()
     else:
         return dic.keys()
 
 def get_itemsview(dic):
-    if hexversion < 0x03000000:
+    if version_info < (3,):
         return dic.viewitems()
     else:
         return dic.items()
@@ -194,7 +194,7 @@ def test_get():
     assert temp.get('A', -1) == -1
 
 def test_has_key():
-    if hexversion > 0x03000000:
+    if version_info > (3,):
         return
     mapping = [(val, pos) for pos, val in enumerate(string.ascii_lowercase)]
     temp = SortedDict(mapping)

--- a/tests/test_coverage_sortedkeylist_modulo.py
+++ b/tests/test_coverage_sortedkeylist_modulo.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from sys import hexversion
+from sys import version_info
 
 import random
 from .context import sortedcontainers
 from sortedcontainers import SortedList, SortedKeyList
 import pytest
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     from itertools import izip as zip
     range = xrange
 

--- a/tests/test_coverage_sortedkeylist_negate.py
+++ b/tests/test_coverage_sortedkeylist_negate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from sys import hexversion
+from sys import version_info
 
 import random
 from .context import sortedcontainers
@@ -8,7 +8,7 @@ from sortedcontainers import SortedKeyList, SortedListWithKey
 from itertools import chain
 import pytest
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     from itertools import izip as zip
     range = xrange
 

--- a/tests/test_coverage_sortedlist.py
+++ b/tests/test_coverage_sortedlist.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from sys import hexversion
+from sys import version_info
 
 import random
 from .context import sortedcontainers
@@ -8,7 +8,7 @@ from sortedcontainers import SortedList
 from itertools import chain
 import pytest
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     from itertools import izip as zip
     range = xrange
 

--- a/tests/test_coverage_sortedset.py
+++ b/tests/test_coverage_sortedset.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from sys import hexversion
+from sys import version_info
 
 import random
 from .context import sortedcontainers
 from sortedcontainers import SortedSet
 import pytest
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     range = xrange
 
 def negate(value):

--- a/tests/test_stress_sorteddict.py
+++ b/tests/test_stress_sorteddict.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
-from sys import hexversion
+from sys import version_info
 
 import random
 from .context import sortedcontainers
 from sortedcontainers import SortedDict
 from functools import wraps
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     from itertools import izip as zip
     range = xrange
 
@@ -86,7 +86,7 @@ def stress_get(sdict):
 
 @actor
 def stress_has_key(sdict):
-    if hexversion > 0x03000000:
+    if version_info > (3,):
         return
     keys = list(range(100))
     for key in keys:

--- a/tests/test_stress_sortedkeylist.py
+++ b/tests/test_stress_sortedkeylist.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
-from sys import hexversion
+from sys import version_info
 
 import copy
 import bisect
@@ -10,7 +10,7 @@ from .context import sortedcontainers
 from sortedcontainers import SortedKeyList
 from functools import wraps
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     from itertools import izip as zip
     range = xrange
 

--- a/tests/test_stress_sortedlist.py
+++ b/tests/test_stress_sortedlist.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
-from sys import hexversion
+from sys import version_info
 
 import copy
 import bisect
@@ -10,7 +10,7 @@ from .context import sortedcontainers
 from sortedcontainers import SortedList
 from functools import wraps
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     from itertools import izip as zip
     range = xrange
 

--- a/tests/test_stress_sortedset.py
+++ b/tests/test_stress_sortedset.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
-from sys import hexversion
+from sys import version_info
 
 import random
 from .context import sortedcontainers
@@ -9,7 +9,7 @@ from sortedcontainers import SortedSet
 from functools import wraps
 import operator
 
-if hexversion < 0x03000000:
+if version_info < (3,):
     from itertools import izip as zip
     range = xrange
 


### PR DESCRIPTION
`sys.version_info` comparisons are more readable and less error-prone.