### PR TITLE
Remove tests/.context shim and test as installed

### DIFF
--- a/tests/benchmark_sorteddict.py
+++ b/tests/benchmark_sorteddict.py
@@ -54,7 +54,6 @@ def fill_values(obj, size):
 
 # Implementation imports.
 
-from .context import sortedcontainers
 from sortedcontainers import SortedDict
 kinds['SortedDict'] = SortedDict
 

--- a/tests/benchmark_sortedlist.py
+++ b/tests/benchmark_sortedlist.py
@@ -104,7 +104,6 @@ def fill_values(obj, size):
 
 # Implementation imports.
 
-from .context import sortedcontainers
 from sortedcontainers import SortedList
 kinds['SortedList'] = SortedList
 

--- a/tests/benchmark_sortedset.py
+++ b/tests/benchmark_sortedset.py
@@ -182,7 +182,6 @@ def fill_values(obj, size):
 
 # Implementation imports.
 
-from .context import sortedcontainers
 from sortedcontainers import SortedSet
 kinds['SortedSet'] = SortedSet
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+# Ignore benchmark tests
+collect_ignore = [
+    "benchmark.py",
+    "benchmark_plot.py",
+    "benchmark_sorteddict.py",
+    "benchmark_sortedlist.py",
+    "benchmark_sortedset.py",
+    "plot_lengths_histogram_add.py",
+    "plot_lengths_histogram_delitem.py",
+]

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-
-import sys
-import os
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
-
-import sortedcontainers

--- a/tests/test_coverage_sorteddict.py
+++ b/tests/test_coverage_sorteddict.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import random, string
-from .context import sortedcontainers
 from sortedcontainers import SortedDict
 import pytest
 from sys import hexversion

--- a/tests/test_coverage_sortedkeylist_modulo.py
+++ b/tests/test_coverage_sortedkeylist_modulo.py
@@ -3,7 +3,6 @@
 from sys import hexversion
 
 import random
-from .context import sortedcontainers
 from sortedcontainers import SortedList, SortedKeyList
 import pytest
 

--- a/tests/test_coverage_sortedkeylist_negate.py
+++ b/tests/test_coverage_sortedkeylist_negate.py
@@ -3,7 +3,6 @@
 from sys import hexversion
 
 import random
-from .context import sortedcontainers
 from sortedcontainers import SortedKeyList, SortedListWithKey
 from itertools import chain
 import pytest

--- a/tests/test_coverage_sortedlist.py
+++ b/tests/test_coverage_sortedlist.py
@@ -3,7 +3,6 @@
 from sys import hexversion
 
 import random
-from .context import sortedcontainers
 from sortedcontainers import SortedList
 from itertools import chain
 import pytest

--- a/tests/test_coverage_sortedset.py
+++ b/tests/test_coverage_sortedset.py
@@ -3,7 +3,6 @@
 from sys import hexversion
 
 import random
-from .context import sortedcontainers
 from sortedcontainers import SortedSet
 import pytest
 

--- a/tests/test_stress_sorteddict.py
+++ b/tests/test_stress_sorteddict.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from sys import hexversion
 
 import random
-from .context import sortedcontainers
 from sortedcontainers import SortedDict
 from functools import wraps
 

--- a/tests/test_stress_sortedkeylist.py
+++ b/tests/test_stress_sortedkeylist.py
@@ -6,7 +6,6 @@ from sys import hexversion
 import copy
 import bisect
 import random
-from .context import sortedcontainers
 from sortedcontainers import SortedKeyList
 from functools import wraps
 

--- a/tests/test_stress_sortedlist.py
+++ b/tests/test_stress_sortedlist.py
@@ -6,7 +6,6 @@ from sys import hexversion
 import copy
 import bisect
 import random
-from .context import sortedcontainers
 from sortedcontainers import SortedList
 from functools import wraps
 

--- a/tests/test_stress_sortedset.py
+++ b/tests/test_stress_sortedset.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from sys import hexversion
 
 import random
-from .context import sortedcontainers
 from sortedcontainers import SortedSet
 from functools import wraps
 import operator

--- a/tox.ini
+++ b/tox.ini
@@ -4,19 +4,14 @@ skip_missing_interpreters=True
 
 [testenv]
 deps=pytest
-commands=python -m pytest
+# Ensure that tests run against installed package
+changedir = {envtmpdir}
+commands = python -m pytest --rootdir={toxinidir} {posargs} {toxinidir}
 
 [pytest]
 addopts=
     --doctest-modules
-    --doctest-glob "*.rst"
-    --ignore tests/benchmark.py
-    --ignore tests/benchmark_plot.py
-    --ignore tests/benchmark_sorteddict.py
-    --ignore tests/benchmark_sortedlist.py
-    --ignore tests/benchmark_sortedset.py
-    --ignore tests/plot_lengths_histogram_add.py
-    --ignore tests/plot_lengths_histogram_delitem.py
+    --doctest-glob "docs/*.rst"
 testpaths=docs sortedcontainers tests
 
 [testenv:lint]


### PR DESCRIPTION
Currently the tests/ folder uses a `context.py` shim to ensure that the `sortedcontainers` folder *in the repository root* is the one that the tests pick up. I believe this is exactly backwards from best practices, (see [my blog post about it](https://blog.ganssle.io/articles/2019/08/test-as-installed.html), and [Hynek Schlawack's related post about the `src/` layout](https://hynek.me/articles/testing-packaging/).

This PR does two things:

1. Removes the `context.py` shim so that the package must be installed or otherwise on the PYTHONPATH via another route (less desirable) before running the tests (`python -m pytest` when run from the repo route will, unfortunately, work for this, but without switching to the `src/` layout, that is unavoidable).

2. Switches the `tox` configuration over to running the tests from a directory other than the repository root, to ensure that everything is being tested as installed. I will note that I needed to switch to using a `conftest.py` file to ignore certain files in the `tests/` directory, because there's no way to tell `pytest` that the `--ignore` options are relative to the repository root.

If you'd like me to add something to the contributing documentation about this, let me know.