### PR TITLE
Modernize build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,6 @@ matrix:
     - python: 3.7
       dist: xenial
       env: TOXENV=lint
+    - python: 3.7
+      dist: xenial
+      env: TOXENV=build-check

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -38,7 +38,7 @@ download the `Sorted Containers zipball`_.
 Once you have a copy of the sources, you can embed it in your Python package,
 or install it into your site-packages using the command::
 
-    $ python3 setup.py install
+    $ pip3 install .
 
 :doc:`Sorted Containers<index>` is available in Debian distributions as
 `python3-sortedcontainers` and `python-sortedcontainers`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,32 @@
+[metadata]
+name = sortedcontainers
+version = attr: sortedcontainers.__version__
+description = Sorted containers -- Sorted List, Sorted Dict, Sorted Set
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = Grant Jenks
+author_email = contact@grantjenks.com
+url = http://www.grantjenks.com/docs/sortedcontainers/
+license = Apache 2.0
+license_files = LICENSE
+python_requires = >=2.7, !=3.0.*, !=3.1.*
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Natural Language :: English
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.2
+    Programming Language :: Python :: 3.3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+
+[options]
+packages = sortedcontainers

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
-import sortedcontainers
-
 
 class Tox(TestCommand):
     def finalize_options(self):
@@ -15,38 +13,7 @@ class Tox(TestCommand):
         exit(errno)
 
 
-with open('README.rst') as reader:
-    readme = reader.read()
-
 setup(
-    name=sortedcontainers.__title__,
-    version=sortedcontainers.__version__,
-    description='Sorted Containers -- Sorted List, Sorted Dict, Sorted Set',
-    long_description=readme,
-    author='Grant Jenks',
-    author_email='contact@grantjenks.com',
-    url='http://www.grantjenks.com/docs/sortedcontainers/',
-    license='Apache 2.0',
-    packages=['sortedcontainers'],
     tests_require=['tox'],
     cmdclass={'test': Tox},
-    install_requires=[],
-    classifiers=(
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Natural Language :: English',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-    ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,14 @@ testpaths=docs sortedcontainers tests
 [testenv:lint]
 deps=pylint
 commands=pylint sortedcontainers
+
+[testenv:build-check]
+description=Builds source and binary packages and uses twine check to validate
+skip_install=True
+changedir={envtmpdir}
+deps=
+    pep517
+    twine
+commands=
+    python -m pep517.build -b -s {toxinidir} -o {envtmpdir}/dist
+    twine check {envtmpdir}/dist/*


### PR DESCRIPTION
Since I really appreciate how clean and well-maintained this repository is, I figured I'd do a quick sweep through to help modernize the build system. The changes are explained in detail in each of the commit messages, but the overview is:

1. Direct invocation of `setup.py install` is soft-deprecated (it's a bad idea to do it, but actually raising warnings in only the right situation is currently a bit tricky), so I've removed one reference to that.
2. We're currently trying to encourage people to use the declarative `setup.cfg` file in favor of `setup.py`. It's much easier to reason about and it's easier to automatically pull metadata from without executing arbitrary code. Most of your metadata can easily be migrated, so I've done that, plus added a few other useful fields like `python_requires`.
3. Added a `pyproject.toml` file for PEP 517/518. *This will change how `pip` builds your project*, but it is intended to be backwards-compatible. This actually relies on some of the changes from the `setup.cfg` file, since when `setup.py` is invoked from a PEP 517 backend, it will no longer have the repository root on the PYTHONPATH. There's a simple workaround for this if you want to add a `pyproject.toml` file without migrating to `setup.cfg`.
4. I have added a build-and-check test to `tox.ini`. Right now you can only invoke it deliberately with `tox -e build-check`, but presumably you'll also want it to execute on CI and possibly add it to the default environments executed when you run `tox`. This relies on the existence of `pyproject.toml`, since `pep517.build` only works with PEP 517 builds.