### PR TITLE
Use chain.from_iterable in sortedset.py

### DIFF
--- a/sortedcontainers/sortedset.py
+++ b/sortedcontainers/sortedset.py
@@ -519,7 +519,7 @@ class SortedSet(MutableSet, Sequence):
         """
         _set = self._set
         _list = self._list
-        values = set(chain(*iterables))
+        values = set(chain.from_iterable(iterables))
         if (4 * len(values)) > len(_set):
             _set.difference_update(values)
             _list.clear()
@@ -655,7 +655,7 @@ class SortedSet(MutableSet, Sequence):
         :return: new sorted set
 
         """
-        return self.__class__(chain(iter(self), *iterables), key=self._key)
+        return self.__class__(chain(iter(self), chain.from_iterable(iterables)), key=self._key)
 
     __or__ = union
     __ror__ = __or__
@@ -679,7 +679,7 @@ class SortedSet(MutableSet, Sequence):
         """
         _set = self._set
         _list = self._list
-        values = set(chain(*iterables))
+        values = set(chain.from_iterable(iterables))
         if (4 * len(values)) > len(_set):
             _list = self._list
             _set.update(values)

--- a/sortedcontainers/sortedset.py
+++ b/sortedcontainers/sortedset.py
@@ -655,7 +655,8 @@ class SortedSet(MutableSet, Sequence):
         :return: new sorted set
 
         """
-        return self.__class__(chain(iter(self), chain.from_iterable(iterables)), key=self._key)
+        return self.__class__(chain(iter(self), chain.from_iterable(iterables)),
+                              key=self._key)
 
     __or__ = union
     __ror__ = __or__


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.