### PR TITLE
Fix update() ordering to be more consistent with add() ordering

### DIFF
--- a/sortedcontainers/sortedlist.py
+++ b/sortedcontainers/sortedlist.py
@@ -339,8 +339,8 @@ class SortedList(MutableSequence):
 
         if _maxes:
             if len(values) * 4 >= self._len:
-                # prepend existing elements to new ones
-                values[0:0] = chain.from_iterable(_lists)
+                _lists.append(values)
+                values = reduce(iadd, _lists, [])
                 values.sort()
                 self._clear()
             else:
@@ -1879,8 +1879,8 @@ class SortedKeyList(SortedList):
 
         if _maxes:
             if len(values) * 4 >= self._len:
-                # prepend existing elements to new ones
-                values[0:0] = chain.from_iterable(_lists)
+                _lists.append(values)
+                values = reduce(iadd, _lists, [])
                 values.sort(key=self._key)
                 self._clear()
             else:

--- a/sortedcontainers/sortedlist.py
+++ b/sortedcontainers/sortedlist.py
@@ -339,7 +339,8 @@ class SortedList(MutableSequence):
 
         if _maxes:
             if len(values) * 4 >= self._len:
-                values.extend(chain.from_iterable(_lists))
+                # prepend existing elements to new ones
+                values[0:0] = chain.from_iterable(_lists)
                 values.sort()
                 self._clear()
             else:
@@ -1878,7 +1879,8 @@ class SortedKeyList(SortedList):
 
         if _maxes:
             if len(values) * 4 >= self._len:
-                values.extend(chain.from_iterable(_lists))
+                # prepend existing elements to new ones
+                values[0:0] = chain.from_iterable(_lists)
                 values.sort(key=self._key)
                 self._clear()
             else:

--- a/tests/test_coverage_sortedkeylist_modulo.py
+++ b/tests/test_coverage_sortedkeylist_modulo.py
@@ -109,16 +109,43 @@ def test_update():
     slt._check()
 
 def test_update_order_consistency():
-    slt = SortedKeyList(key=lambda x: x[0])
+    def modulo_el0(tup):
+        return tup[0] % 10
 
-    it1 = list(zip(repeat(0), range(4)))
-    it2 = list(zip(repeat(0), range(5)))
+    slt1 = SortedKeyList(key=modulo_el0)
+    slt2 = SortedKeyList(key=modulo_el0)
 
-    slt.update(it1)
-    slt.update(it2)
-    slt._check()
+    def add_from_iterable(slt, it):
+        for item in it:
+            slt.add(item)
 
-    assert all(tup[0] == tup[1] for tup in zip(slt, chain(it1, it2)))
+    def add_from_all_iterables(slt, its):
+        for it in its:
+            add_from_iterable(slt, it)
+
+    def update_from_all_iterables(slt, its):
+        for it in its:
+            slt.update(it)
+
+    # the following iterators are set up (from large to small) such that they
+    # attempt to force the two kinds of internal update logic (extending upon
+    # the incoming iterable or appending to the existing elements by use of
+    # `add()`)
+    it1 = list(zip(repeat(0), range(5)))
+    it2 = list(zip(repeat(0), range(4)))
+    it3 = list(zip(repeat(0), range(3)))
+    it4 = list(zip(repeat(0), range(2)))
+    it5 = list(zip(repeat(0), range(1)))
+
+    it12345 = [it1, it2, it3, it4, it5]
+
+    add_from_all_iterables(slt1, it12345)
+    update_from_all_iterables(slt2, it12345)
+
+    slt1._check()
+    slt2._check()
+
+    assert all(tup[0] == tup[1] for tup in zip(slt1, slt2))
 
 def test_contains():
     slt = SortedKeyList(key=modulo)

--- a/tests/test_coverage_sortedkeylist_modulo.py
+++ b/tests/test_coverage_sortedkeylist_modulo.py
@@ -5,6 +5,7 @@ from sys import hexversion
 import random
 from .context import sortedcontainers
 from sortedcontainers import SortedList, SortedKeyList
+from itertools import chain, repeat
 import pytest
 
 if hexversion < 0x03000000:
@@ -106,6 +107,18 @@ def test_update():
     slt.update(range(10000))
     assert len(slt) == 11000
     slt._check()
+
+def test_update_order_consistency():
+    slt = SortedKeyList(key=lambda x: x[0])
+
+    it1 = list(zip(repeat(0), range(4)))
+    it2 = list(zip(repeat(0), range(5)))
+
+    slt.update(it1)
+    slt.update(it2)
+    slt._check()
+
+    assert all(tup[0] == tup[1] for tup in zip(slt, chain(it1, it2)))
 
 def test_contains():
     slt = SortedKeyList(key=modulo)

--- a/tests/test_coverage_sortedkeylist_negate.py
+++ b/tests/test_coverage_sortedkeylist_negate.py
@@ -5,7 +5,7 @@ from sys import hexversion
 import random
 from .context import sortedcontainers
 from sortedcontainers import SortedKeyList, SortedListWithKey
-from itertools import chain
+from itertools import chain, repeat
 import pytest
 
 if hexversion < 0x03000000:
@@ -83,6 +83,18 @@ def test_update():
 
     values = sorted((val for val in chain(range(100), range(1000), range(10000))), key=negate)
     assert all(tup[0] == tup[1] for tup in zip(slt, values))
+
+def test_update_order_consistency():
+    slt = SortedKeyList(key=lambda x: x[0])
+
+    it1 = list(zip(repeat(0), range(4)))
+    it2 = list(zip(repeat(0), range(5)))
+
+    slt.update(it1)
+    slt.update(it2)
+    slt._check()
+
+    assert all(tup[0] == tup[1] for tup in zip(slt, chain(it1, it2)))
 
 def test_contains():
     slt = SortedKeyList(key=negate)


### PR DESCRIPTION
This pull request fixes #158 by prepending existing elements to new ones (to stick with the same ordering as the `add()` method).

I have run the included `tox` tests and benchmarks offline and have not seen any noticeable difference in performance after looking at the benchmark plots.