### PR TITLE
Update SortedDict example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,11 +24,11 @@ In Python, we can do better. And we can do it in pure-Python!
     >>> sl[-3:]
     ['e', 'e', 'e']
     >>> from sortedcontainers import SortedDict
-    >>> sd = SortedDict({'c': 3, 'a': 1, 'b': 2})
+    >>> sd = SortedDict({'c': -3, 'a': 1, 'b': 2})
     >>> sd
-    SortedDict({'a': 1, 'b': 2, 'c': 3})
+    SortedDict({'a': 1, 'b': 2, 'c': -3})
     >>> sd.popitem(index=-1)
-    ('c', 3)
+    ('c', -3)
     >>> from sortedcontainers import SortedSet
     >>> ss = SortedSet('abracadabra')
     >>> ss


### PR DESCRIPTION
The new example makes it clear that sort is due to the key and not the value.