### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ setup(
     author='Grant Jenks',
     author_email='contact@grantjenks.com',
     url='http://www.grantjenks.com/docs/sortedcontainers/',
+    project_urls={
+        'Source': 'https://github.com/grantjenks/python-sortedcontainers',
+    },
     license='Apache 2.0',
     packages=['sortedcontainers'],
     tests_require=['tox'],


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.