### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -362,7 +362,7 @@ Python, these have a `total ordering`_:
 
 2. Strings and bytes.
 
-3. All foating-point numbers except ``float('nan')``.
+3. All floating-point numbers except ``float('nan')``.
 
 4. Sequences like `list` and `tuple` of values with a total ordering.
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -41,11 +41,11 @@ mutating operations. When unable to preserve the sorted order constraint, the
 functionality is either non-existent or an error is raised from the
 library. Python's "sorted" built-in function also supports a "key" parameter
 which specifies a callable used to extract a comparison key from elements. When
-initializing a sorted container data type, the key paramemter is likewise
+initializing a sorted container data type, the key parameter is likewise
 supported.
 
 Internally, Python Sorted Containers uses a list of sublists data structure
-that is like a B-tree contstrained to two levels of nodes. The maximum of each
+that is like a B-tree constrained to two levels of nodes. The maximum of each
 sublist is maintained in a separate list. To lookup an element, the list of
 maximums is bisected using the "bisect" module in the Standard Library. Using
 the bisected maximums index, the corresponding sublist is bisected to find the

--- a/tests/sortedcollection.py
+++ b/tests/sortedcollection.py
@@ -159,7 +159,7 @@ class SortedCollection(object):
         self._items.insert(i, item)
 
     def remove(self, item):
-        'Remove first occurence of item.  Raise ValueError if not found'
+        'Remove first occurrence of item.  Raise ValueError if not found'
         i = self.index(item)
         del self._keys[i]
         del self._items[i]


### PR DESCRIPTION
There are small typos in:
- docs/introduction.rst
- docs/paper.md
- tests/sortedcollection.py

Fixes:
- Should read `parameter` rather than `paramemter`.
- Should read `occurrence` rather than `occurence`.
- Should read `floating` rather than `foating`.
- Should read `constrained` rather than `contstrained`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md