### PR TITLE
Pin pylint development dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ doc8
 gj
 matplotlib
 pyannote-banyan
-pylint
+pylint<2.6
 pytest
 pytest-cov
 rstcheck

--- a/tox.ini
+++ b/tox.ini
@@ -20,5 +20,5 @@ addopts=
 testpaths=docs sortedcontainers tests
 
 [testenv:lint]
-deps=pylint
+deps=pylint<2.6
 commands=pylint sortedcontainers


### PR DESCRIPTION
The pylint configuration kept in .pylintrc is incompatible with up-to-date releases of pylint. In particular, [pylint 2.6](https://pylint.pycqa.org/en/2.6/whatsnew/2.6.html) introduced breaking changes, such as removing the `no-space-check` option.

Consequently, when setting up a local clone of this repo and running `python setup.py test`, pylint fails with numerous warnings and errors.

As a work-around, this trivial PR pins pylint to the last supported version. The test suite successfully completes.

The pin may be relaxed as soon as the pylint configuration has been overhauled. This is out-of-scope for this PR.