### PR TITLE
Remove support for EOL versions of CPython as well as PyPy2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ install: pip install tox
 script: tox
 matrix:
   include:
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ install: pip install tox
 script: tox
 matrix:
   include:
-    - python: 3.5
-      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ install: pip install tox
 script: tox
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     - python: 3.7
       dist: xenial
       env: TOXENV=py37
-    - python: pypy
-      env: TOXENV=pypy
     - python: pypy3
       env: TOXENV=pypy3
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ install: pip install tox
 script: tox
 matrix:
   include:
-    - python: 3.6
-      env: TOXENV=py36
     - python: 3.7
       dist: xenial
       env: TOXENV=py37

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Features
 - Feature-rich (e.g. get the five largest keys in a sorted dict: d.keys()[-5:])
 - Pragmatic design (e.g. SortedSet is a Python set with a SortedList index)
 - Developed on Python 3.7
-- Tested on CPython 3.4, 3.5, 3.6, 3.7 and PyPy, PyPy3
+- Tested on CPython 3.5, 3.6, 3.7 and PyPy, PyPy3
 
 .. image:: https://api.travis-ci.org/grantjenks/python-sortedcontainers.svg?branch=master
    :target: http://www.grantjenks.com/docs/sortedcontainers/

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Features
 - Feature-rich (e.g. get the five largest keys in a sorted dict: d.keys()[-5:])
 - Pragmatic design (e.g. SortedSet is a Python set with a SortedList index)
 - Developed on Python 3.7
-- Tested on CPython 3.3, 3.4, 3.5, 3.6, 3.7 and PyPy, PyPy3
+- Tested on CPython 3.4, 3.5, 3.6, 3.7 and PyPy, PyPy3
 
 .. image:: https://api.travis-ci.org/grantjenks/python-sortedcontainers.svg?branch=master
    :target: http://www.grantjenks.com/docs/sortedcontainers/

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Features
 - Feature-rich (e.g. get the five largest keys in a sorted dict: d.keys()[-5:])
 - Pragmatic design (e.g. SortedSet is a Python set with a SortedList index)
 - Developed on Python 3.7
-- Tested on CPython 3.7 and PyPy, PyPy3
+- Tested on CPython 3.7 and PyPy3
 
 .. image:: https://api.travis-ci.org/grantjenks/python-sortedcontainers.svg?branch=master
    :target: http://www.grantjenks.com/docs/sortedcontainers/

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Features
 - Feature-rich (e.g. get the five largest keys in a sorted dict: d.keys()[-5:])
 - Pragmatic design (e.g. SortedSet is a Python set with a SortedList index)
 - Developed on Python 3.7
-- Tested on CPython 2.7, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7 and PyPy, PyPy3
+- Tested on CPython 3.2, 3.3, 3.4, 3.5, 3.6, 3.7 and PyPy, PyPy3
 
 .. image:: https://api.travis-ci.org/grantjenks/python-sortedcontainers.svg?branch=master
    :target: http://www.grantjenks.com/docs/sortedcontainers/

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Features
 - Feature-rich (e.g. get the five largest keys in a sorted dict: d.keys()[-5:])
 - Pragmatic design (e.g. SortedSet is a Python set with a SortedList index)
 - Developed on Python 3.7
-- Tested on CPython 3.2, 3.3, 3.4, 3.5, 3.6, 3.7 and PyPy, PyPy3
+- Tested on CPython 3.3, 3.4, 3.5, 3.6, 3.7 and PyPy, PyPy3
 
 .. image:: https://api.travis-ci.org/grantjenks/python-sortedcontainers.svg?branch=master
    :target: http://www.grantjenks.com/docs/sortedcontainers/

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Features
 - Feature-rich (e.g. get the five largest keys in a sorted dict: d.keys()[-5:])
 - Pragmatic design (e.g. SortedSet is a Python set with a SortedList index)
 - Developed on Python 3.7
-- Tested on CPython 3.6, 3.7 and PyPy, PyPy3
+- Tested on CPython 3.7 and PyPy, PyPy3
 
 .. image:: https://api.travis-ci.org/grantjenks/python-sortedcontainers.svg?branch=master
    :target: http://www.grantjenks.com/docs/sortedcontainers/

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Features
 - Feature-rich (e.g. get the five largest keys in a sorted dict: d.keys()[-5:])
 - Pragmatic design (e.g. SortedSet is a Python set with a SortedList index)
 - Developed on Python 3.7
-- Tested on CPython 3.5, 3.6, 3.7 and PyPy, PyPy3
+- Tested on CPython 3.6, 3.7 and PyPy, PyPy3
 
 .. image:: https://api.travis-ci.org/grantjenks/python-sortedcontainers.svg?branch=master
    :target: http://www.grantjenks.com/docs/sortedcontainers/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,7 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,9 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,8 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -254,7 +254,6 @@ Tested Runtimes
 of Python:
 
 * CPython 3.7
-* PyPy
 * PyPy3
 
 Life will feel much saner if you use `venv`_ or `virtualenv`_ and `tox`_ to

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -253,7 +253,6 @@ Tested Runtimes
 :doc:`Sorted Containers<index>` actively tests against the following versions
 of Python:
 
-* CPython 3.4
 * CPython 3.5
 * CPython 3.6
 * CPython 3.7

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -253,7 +253,6 @@ Tested Runtimes
 :doc:`Sorted Containers<index>` actively tests against the following versions
 of Python:
 
-* CPython 3.6
 * CPython 3.7
 * PyPy
 * PyPy3

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -253,7 +253,6 @@ Tested Runtimes
 :doc:`Sorted Containers<index>` actively tests against the following versions
 of Python:
 
-* CPython 3.3
 * CPython 3.4
 * CPython 3.5
 * CPython 3.6

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -253,7 +253,6 @@ Tested Runtimes
 :doc:`Sorted Containers<index>` actively tests against the following versions
 of Python:
 
-* CPython 3.2
 * CPython 3.3
 * CPython 3.4
 * CPython 3.5

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -253,7 +253,6 @@ Tested Runtimes
 :doc:`Sorted Containers<index>` actively tests against the following versions
 of Python:
 
-* CPython 2.7
 * CPython 3.2
 * CPython 3.3
 * CPython 3.4

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -253,7 +253,6 @@ Tested Runtimes
 :doc:`Sorted Containers<index>` actively tests against the following versions
 of Python:
 
-* CPython 3.5
 * CPython 3.6
 * CPython 3.7
 * PyPy

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py37,pypy,pypy3,lint
+envlist=py37,pypy3,lint
 skip_missing_interpreters=True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,pypy,pypy3,lint
+envlist=py34,py35,py36,py37,pypy,pypy3,lint
 skip_missing_interpreters=True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py35,py36,py37,pypy,pypy3,lint
+envlist=py36,py37,pypy,pypy3,lint
 skip_missing_interpreters=True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py34,py35,py36,py37,pypy,pypy3,lint
+envlist=py35,py36,py37,pypy,pypy3,lint
 skip_missing_interpreters=True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36,py37,pypy,pypy3,lint
+envlist=py37,pypy,pypy3,lint
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
All versions of CPython before 3.7 have reached their end of life. PyPy2.7 is still officially supported, but inherits legacy Python 2 syntax.

Moving up the minimum supported version of Python to 3.7 makes available modern syntax and functionality of the standard library. This should simplify further development and maintenance of sortedcontainers (#199).

This PR removes state support for EOL CPython versions and PyPy2.7 from:
* project documentation
* package classifiers
* tests
* Travis CI

It **does not**:
* modernize code
* remove compatibility shims
* update historic benchmarks etc.
* Extend stated support for CPython 3.8 and beyond