### PR TITLE
docs: Update an example of DefaultSortedDict so that it works appropriately.

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -618,7 +618,8 @@ method creates a kind of `defaultdict` like that in the `collections` module.
 
     >>> class DefaultSortedDict(SortedDict):
     ...     def __missing__(self, key):
-    ...         return 0
+    ...         self[key] = 0
+    ...         return self[key]
     >>> dsd = DefaultSortedDict()
     >>> dsd['z']
     0

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -618,8 +618,9 @@ method creates a kind of `defaultdict` like that in the `collections` module.
 
     >>> class DefaultSortedDict(SortedDict):
     ...     def __missing__(self, key):
-    ...         self[key] = 0
-    ...         return self[key]
+    ...         value = 0
+    ...         self[key] = value
+    ...         return value
     >>> dsd = DefaultSortedDict()
     >>> dsd['z']
     0


### PR DESCRIPTION
# Summary 
* Update the introduction document so that the example related to DefaultSortedDict works appropriately.

# Background
* The Introduction document describes how to make SortedDict have a default value like defaultdict, but its behavior is different from the original one, and it causes data loss in some use cases.

* In defaultdict, it will create a new entry with the accessed key if there is no entry corresponding to the given key. But the current document's example does not create an entry.

* For example, If the default value was an instance of `list,` `dsd[“missing_key”].append(some_object)` successes without errors, but the dictionary remains empty, thus causing unintentional data loss.

# Related Issues:
https://github.com/grantjenks/python-sortedcontainers/issues/74

# P.S
If this change looks good, please feel free to merge anytime. Thank you.