### PR TITLE
Removed unnecessary variable initialization from discard method on so…

### DIFF
--- a/src/sortedcontainers/sortedset.py
+++ b/src/sortedcontainers/sortedset.py
@@ -391,9 +391,8 @@ class SortedSet(MutableSet, Sequence):
         :param value: `value` to discard from sorted set
 
         """
-        _set = self._set
-        if value in _set:
-            _set.remove(value)
+        if value in self._set:
+            self._set.remove(value)
             self._list.remove(value)
 
     _discard = discard


### PR DESCRIPTION
…rted sets

We can avoid declaring _set variable and directly access self._set. For now doing this in discard method only. I can work on entire code base to remove unnecessary allocations, only in the places where this does not adversely affect  the readability