### PR TITLE
Add support for Python 3.13-3.14 and drop EOL 3.2-3.9

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,11 +20,11 @@ jobs:
         check: [rufflint, ruffformatcheck, doc8, docs, rstcheck, build-check]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.x'
       - name: Install tox
         run: |
           pip install --upgrade pip
@@ -40,12 +40,12 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,7 +40,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13, 3.14]
+        python-version: ['3.10', 3.11, 3.12, 3.13, 3.14]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,9 +20,9 @@ jobs:
         check: [rufflint, ruffformatcheck, doc8, docs, rstcheck, build-check]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install tox
@@ -40,12 +40,12 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13, 3.14]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.x'
 
     - name: Install build
       run: pip install build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Features
 - Feature-rich (e.g. get the five largest keys in a sorted dict: d.keys()[-5:])
 - Pragmatic design (e.g. SortedSet is a Python set with a SortedList index)
 - Developed on Python 3.10
-- Tested with CPython 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and PyPy3
+- Tested with CPython 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and PyPy3
 - Tested on Linux, Mac OSX, and Windows
 
 .. image:: https://github.com/grantjenks/python-sortedcontainers/workflows/integration/badge.svg

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Features
 - Feature-rich (e.g. get the five largest keys in a sorted dict: d.keys()[-5:])
 - Pragmatic design (e.g. SortedSet is a Python set with a SortedList index)
 - Developed on Python 3.10
-- Tested with CPython 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 and PyPy3
+- Tested with CPython 3.10, 3.11, 3.12, 3.13, 3.14 and PyPy3
 - Tested on Linux, macOS, and Windows
 
 .. image:: https://github.com/grantjenks/python-sortedcontainers/workflows/integration/badge.svg

--- a/README.rst
+++ b/README.rst
@@ -112,8 +112,8 @@ Features
 - Feature-rich (e.g. get the five largest keys in a sorted dict: d.keys()[-5:])
 - Pragmatic design (e.g. SortedSet is a Python set with a SortedList index)
 - Developed on Python 3.10
-- Tested with CPython 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and PyPy3
-- Tested on Linux, Mac OSX, and Windows
+- Tested with CPython 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 and PyPy3
+- Tested on Linux, macOS, and Windows
 
 .. image:: https://github.com/grantjenks/python-sortedcontainers/workflows/integration/badge.svg
    :target: http://www.grantjenks.com/docs/sortedcontainers/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,8 +176,7 @@ texinfo_documents = [
         'SortedContainers Documentation',
         author,
         'SortedContainers',
-        'Python sorted collections library:'
-        ' sorted list, sorted dict, and sorted set.',
+        'Python sorted collections library: sorted list, sorted dict, and sorted set.',
         'Miscellaneous',
     ),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {"name" = "Grant Jenks", "email" = "contact@grantjenks.com"},
 ]
 readme = "README.rst"
-requires-python = ">=3.2"
+requires-python = ">=3.10"
 license = {"text" = "Apache 2.0"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/sortedcontainers/sorteddict.py
+++ b/src/sortedcontainers/sorteddict.py
@@ -191,7 +191,7 @@ class SortedDict(dict):
             return self._iloc
         except AttributeError:
             warnings.warn(
-                'sorted_dict.iloc is deprecated.' ' Use SortedDict.keys() instead.',
+                'sorted_dict.iloc is deprecated. Use SortedDict.keys() instead.',
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/sortedcontainers/sortedlist.py
+++ b/src/sortedcontainers/sortedlist.py
@@ -668,7 +668,7 @@ class SortedList(MutableSequence):
 
         head = iter(row0)
         tail = iter(head)
-        row1 = list(starmap(add, zip(head, tail)))
+        row1 = list(starmap(add, zip(head, tail, strict=False)))
 
         if len(row0) & 1:
             row1.append(row0[-1])
@@ -685,7 +685,7 @@ class SortedList(MutableSequence):
         while len(tree[-1]) > 1:
             head = iter(tree[-1])
             tail = iter(head)
-            row = list(starmap(add, zip(head, tail)))
+            row = list(starmap(add, zip(head, tail, strict=False)))
             tree.append(row)
 
         reduce(iadd, reversed(tree), self._index)
@@ -1466,7 +1466,7 @@ class SortedList(MutableSequence):
                 if seq_op is ne:
                     return True
 
-            for alpha, beta in zip(self, other):
+            for alpha, beta in zip(self, other, strict=False):
                 if alpha != beta:
                     return seq_op(alpha, beta)
 
@@ -2467,9 +2467,9 @@ class SortedKeyList(SortedList):
 
             # Check _keys matches _key mapped to _lists.
 
-            for val_sublist, key_sublist in zip(self._lists, self._keys):
+            for val_sublist, key_sublist in zip(self._lists, self._keys, strict=False):
                 assert len(val_sublist) == len(key_sublist)
-                for val, key in zip(val_sublist, key_sublist):
+                for val, key in zip(val_sublist, key_sublist, strict=False):
                     assert self._key(val) == key
 
             # Check _maxes index is the last value of each sublist.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=rufflint,ruffformatcheck,doc8,docs,rstcheck,build-check,py{38,39,310,311,312,py3}
+envlist=rufflint,ruffformatcheck,doc8,docs,rstcheck,build-check,py{38,39,310,311,312,313,py3}
 skip_missing_interpreters=True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=rufflint,ruffformatcheck,doc8,docs,rstcheck,build-check,py{38,39,310,311,312,313,py3}
+envlist=rufflint,ruffformatcheck,doc8,docs,rstcheck,build-check,py{38,39,310,311,312,313,314,py3}
 skip_missing_interpreters=True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=rufflint,ruffformatcheck,doc8,docs,rstcheck,build-check,py{38,39,310,311,312,313,314,py3}
+envlist=rufflint,ruffformatcheck,doc8,docs,rstcheck,build-check,py{310,311,312,313,314,py3}
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
3.13 was released in October:

https://devguide.python.org/versions/